### PR TITLE
Add support for attachment types in message imports

### DIFF
--- a/prisma/migrations/20250707003405_add_asset_type_field/migration.sql
+++ b/prisma/migrations/20250707003405_add_asset_type_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Asset" ADD COLUMN "type" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Link {
 model Asset {
   id        Int     @id @default(autoincrement())
   filename  String
+  type      String?
   messageId Int
   message   Message @relation(fields: [messageId], references: [id])
 }


### PR DESCRIPTION
### Summary
Adds functionality to parse and associate attachment types with filenames during message imports. Updates the database schema to include an optional `type` field for assets, enhancing data structure extensibility.

### Changes
- **Database Schema**: Adds a nullable `type` column to the `Asset` table for storing attachment types.
- **Import Logic**: Updates parsing logic to handle attachment types, matching them with filenames by index.
- **Hashing**: Modifies hashing logic to include attachment types for improved data validation.
- **Unit Tests**: Expands test coverage to verify correct handling of attachment types and updates mock data and expectations.

### Benefits
- Enables more detailed asset classification by associating file types with attachments.
- Improves extensibility for future asset-related features.
- Enhances data accuracy and validation during imports.

Relates to feature enhancement for attachment handling in message imports.