### PR TITLE
Update agent policies for single-task execution

### DIFF
--- a/.claude/agents/spec-reader.md
+++ b/.claude/agents/spec-reader.md
@@ -1,4 +1,5 @@
 ---
+# Policy: This agent only selects and operates on the next incomplete top-level task (and its subtasks) from the provided tasks.md. Do not batch or process multiple tasks at once.
 name: spec-reader
 description: Reads all spec .md files, summarizes tasks, and checks progress before picking up work (AgentOS-aware)
 model: sonnet
@@ -33,9 +34,11 @@ When invoked, you will:
 
 1. Read all `.md` files in the spec directory (recursively) to gather full context
 2. Check task progress and status by reading the `tasks.md` file in the spec directory
-3. Detect if a task is already started, in progress, or completed by inspecting `tasks.md`
-4. Summarize available, in-progress, and completed tasks for the user
-5. Output a summary before picking up any new work
+3. If no task is provided, determine which top-level task (and its subtasks) is currently in progress by inspecting `tasks.md`, and operate on that. Otherwise, select the next incomplete top-level task (and its subtasks) for each run. Do not batch or process multiple tasks at once.
+4. Pass the selected or in-progress task (and its subtasks) to downstream agents for execution, ensuring only one task is operated on per run.
+5. Detect if a task is already started, in progress, or completed by inspecting `tasks.md`
+6. Summarize available, in-progress, and completed tasks for the user
+7. Output a summary before picking up any new work
 
 ## Operating Principles
 

--- a/.claude/agents/task-executor.md
+++ b/.claude/agents/task-executor.md
@@ -1,4 +1,5 @@
 ---
+# Policy: This agent only selects and operates on the next incomplete top-level task (and its subtasks) from the provided tasks.md. Do not batch or process multiple tasks at once.
 name: task-executor
 description: Executes tasks defined in tasks.md, updates progress, and provides status feedback (AgentOS-aware)
 model: sonnet
@@ -31,11 +32,12 @@ You are the **task-executor** agent. Your role is to execute tasks as defined in
 
 When invoked, you will:
 
-1. Read the `tasks.md` file in the spec directory to identify tasks and their status
-2. Execute the specified task, using context from related Markdown spec files
-3. Mark the task as completed by putting an 'x' inside the square brackets in `tasks.md`, or mark as not completed by removing the 'x'
-4. Provide status feedback to the user after each operation
-5. Output a summary of actions taken and next steps
+1. Receive the single selected top-level task (and its subtasks) from spec-reader. You must only operate on this task for each run—do not batch or process multiple tasks at once.
+2. Read the `tasks.md` file in the spec directory to identify tasks and their status
+3. Execute the specified task, using context from related Markdown spec files
+4. Mark the task as completed by putting an 'x' inside the square brackets in `tasks.md`, or mark as not completed by removing the 'x'
+5. Provide status feedback to the user after each operation
+6. Output a summary of actions taken and next steps
 
 ## Operating Principles
 


### PR DESCRIPTION
## Summary

This PR adds important policy statements to the spec-reader and task-executor agents to ensure they process only one top-level task at a time.

## Changes

### Agent Policy Updates
- **spec-reader.md**: Added policy to select and operate on only the next incomplete top-level task
- **task-executor.md**: Added policy to execute only the single selected task per run

## Benefits

- **Focused Execution**: Prevents batch processing of multiple tasks
- **Better Traceability**: Each agent run focuses on a single task
- **Improved Reliability**: Reduces complexity and potential errors
- **Clear Workflow**: Maintains AgentOS principles of atomic task execution

## Technical Details

The policies are added as YAML frontmatter comments to ensure they are parsed correctly while maintaining readability:

```yaml
---
# Policy: This agent only selects and operates on the next incomplete top-level task (and its subtasks) from the provided tasks.md. Do not batch or process multiple tasks at once.
name: agent-name
...
---
```

This ensures proper task isolation and sequential processing in the agentic workflow.